### PR TITLE
05.26 ~ 06.01 정유민

### DIFF
--- a/01_스택/9935_문자열 폭발/정유민.java
+++ b/01_스택/9935_문자열 폭발/정유민.java
@@ -1,0 +1,48 @@
+// 언어 : JAVA , (성공/실패) : 1/0 , 메모리 : 26796 KB , 시간 : 232 ms
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class 정유민 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String s = br.readLine();
+        String bomb = br.readLine();
+        int n = s.length();
+        int m = bomb.length();
+
+        char[] stack = new char[n];
+        int top = 0;
+
+        for (int i = 0; i < n; i++) {
+            stack[top++] = s.charAt(i);
+
+            // 폭발 문자열 길이 이상 쌓였으면 매칭 검사
+            if (top >= m) {
+                boolean matched = true;
+                for (int j = 0; j < m; j++) {
+                    if (stack[top - m + j] != bomb.charAt(j)) {
+                        matched = false;
+                        break;
+                    }
+                }
+                // 매칭되면 pop
+                if (matched) {
+                    top -= m;
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder(top);
+        for (int i = 0; i < top; i++) {
+            sb.append(stack[i]);
+        }
+
+        if (sb.length() == 0) {
+            System.out.println("FRULA");
+        } else {
+            System.out.println(sb);
+        }
+    }
+}


### PR DESCRIPTION
## boj9935_문자열 폭발
처음에 Deque 로 구현하려다 뭔가 인덱스 접근이 불편한 것 같아 char[] 배열을 스택처럼 쓰고 top 포인터만 조작하도록 바꿔서, 폭발 문자열 길이만큼만 비교하고 지우는 방식으로 풀었다. 한 20번 틀리고 도저히 못풀겠어서 gpt 에게 약간의 힌트를 얻고 풀었다. 그냥 기분 겸 제출해버렸다.

## 세 용액
이 문제는 풀지 못하여 패스권 사용하도록 하겠습니다.